### PR TITLE
Fix prop names and list handling

### DIFF
--- a/caddy-ui-manager/index.html
+++ b/caddy-ui-manager/index.html
@@ -1,4 +1,3 @@
-.html -->
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/caddy-ui-manager/src/App.tsx
+++ b/caddy-ui-manager/src/App.tsx
@@ -5,6 +5,7 @@ import { readCaddyFile, writeCaddyFile } from './services/fileService';
 
 const App = () => {
     const [proxyEntries, setProxyEntries] = useState([]);
+    const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
     useEffect(() => {
         const fetchEntries = async () => {
@@ -20,10 +21,23 @@ const App = () => {
         await writeCaddyFile(updatedEntries);
     };
 
+    const handleEntrySubmit = async (entry) => {
+        if (editingIndex !== null) {
+            await editProxyEntry(editingIndex, entry);
+            setEditingIndex(null);
+        } else {
+            await addProxyEntry(entry);
+        }
+    };
+
     const editProxyEntry = async (index, updatedEntry) => {
         const updatedEntries = proxyEntries.map((entry, i) => (i === index ? updatedEntry : entry));
         setProxyEntries(updatedEntries);
         await writeCaddyFile(updatedEntries);
+    };
+
+    const startEditingEntry = (index: number) => {
+        setEditingIndex(index);
     };
 
     const deleteProxyEntry = async (index) => {
@@ -35,10 +49,10 @@ const App = () => {
     return (
         <div>
             <h1>Caddy Reverse Proxy Manager</h1>
-            <ProxyEntryForm onAddEntry={addProxyEntry} />
-            <ProxyEntryList 
-                entries={proxyEntries} 
-                onEdit={editProxyEntry} // Corrected prop name
+            <ProxyEntryForm onSubmit={handleEntrySubmit} initialEntry={editingIndex !== null ? proxyEntries[editingIndex] : undefined} />
+            <ProxyEntryList
+                entries={proxyEntries}
+                onEdit={startEditingEntry}
                 onDelete={deleteProxyEntry} // Corrected prop name
             />
         </div>

--- a/caddy-ui-manager/src/components/ProxyEntryForm.tsx
+++ b/caddy-ui-manager/src/components/ProxyEntryForm.tsx
@@ -1,7 +1,17 @@
 import React, { useState } from 'react';
 
-const ProxyEntryForm = ({ onSubmit, initialEntry }) => {
-    const [entry, setEntry] = useState(initialEntry || { domain: '', target: '' });
+interface ProxyEntry {
+    domain: string;
+    target: string;
+}
+
+interface ProxyEntryFormProps {
+    onSubmit: (entry: ProxyEntry) => void;
+    initialEntry?: ProxyEntry | null;
+}
+
+const ProxyEntryForm: React.FC<ProxyEntryFormProps> = ({ onSubmit, initialEntry }) => {
+    const [entry, setEntry] = useState<ProxyEntry>(initialEntry || { domain: '', target: '' });
 
     const handleChange = (e) => {
         const { name, value } = e.target;

--- a/caddy-ui-manager/src/components/ProxyEntryList.tsx
+++ b/caddy-ui-manager/src/components/ProxyEntryList.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 
 interface ProxyEntry {
-    id: number;
     domain: string;
     target: string;
 }
 
 interface ProxyEntryListProps {
     entries: ProxyEntry[];
-    onEdit: (entry: ProxyEntry) => void;
-    onDelete: (id: number) => void;
+    onEdit: (index: number) => void;
+    onDelete: (index: number) => void;
 }
 
 const ProxyEntryList: React.FC<ProxyEntryListProps> = ({ entries, onEdit, onDelete }) => {
@@ -17,11 +16,11 @@ const ProxyEntryList: React.FC<ProxyEntryListProps> = ({ entries, onEdit, onDele
         <div>
             <h2>Proxy Entries</h2>
             <ul>
-                {entries.map(entry => (
-                    <li key={entry.id}>
+                {entries.map((entry, index) => (
+                    <li key={index}>
                         <span>{entry.domain} {'>'} {entry.target}</span>
-                        <button onClick={() => onEdit(entry)}>Edit</button>
-                        <button onClick={() => onDelete(entry.id)}>Delete</button>
+                        <button onClick={() => onEdit(index)}>Edit</button>
+                        <button onClick={() => onDelete(index)}>Delete</button>
                     </li>
                 ))}
             </ul>


### PR DESCRIPTION
## Summary
- fix prop name for ProxyEntryForm
- adjust ProxyEntryList to work with index-based entries
- add editing capability via `startEditingEntry`
- move index.html so Vite build succeeds

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_683fb24087ac8326a676ac0a738f7e28